### PR TITLE
Ease Result Fetching

### DIFF
--- a/camelot_pro/__init__.py
+++ b/camelot_pro/__init__.py
@@ -36,15 +36,13 @@ def read_pdf(
                     optional, if processing a new file
                     Mandatory, to retrieve the result of already submitted file
 
-                "dup_check": bool, default: false - to bypass the duplicate check
+                "dup_check": bool, default: False - to bypass the duplicate check
                     Useful to handle duplicate requests, check based on the FileName
 
-
-                "wait_time": int, in seconds [10, 90]
-                    Maximum wait time, in seconds, before the process exits as an output.
-                    Adds a wait time at the client-side to retry for a maximum of 4 times,
-                    with at least 10 second gap in between retries
-                        - If the process is successful before the 4 retries, the process will return the output
+                "wait_for_output": bool, default: True
+                    Loops and check for the output for a maximum of 300 seconds, before the process exits as an output.
+                    with 20 second gap in between retries
+                        - If the process will return the output before 300 seconds, when the processing is successful
                         - Alternatively, a big file process can always be tracked using the ".JobId" from the output
             }
         )
@@ -67,16 +65,16 @@ def read_pdf(
             gp_resp = gone_pro.get_tables(pro_kwargs["job_id"])
 
         # Added default wait time, because early users are confused of no output
-        pro_kwargs["wait_time"] = pro_kwargs.get("wait_time", 30)
+        pro_kwargs["wait_for_output"] = pro_kwargs.get("wait_for_output", True)
 
-        if gp_resp["JobStatus"].lower().startswith("process") and pro_kwargs["wait_time"]:
-            wait_time = min(int(pro_kwargs["wait_time"]), 90)
-            check_freq = max(math.ceil(wait_time/4), 10)
-            for _ in range(math.ceil(wait_time/check_freq)):
+        if gp_resp["JobStatus"].lower().startswith("process") and pro_kwargs["wait_for_output"]:
+            max_wait = 300
+            check_freq = 20
+            while max_wait > 0 and gp_resp["JobStatus"].lower().startswith("process"):
+                print(f'[Info]: Please wait, the Job is: {gp_resp["JobStatus"]} ..')
+                max_wait -= check_freq
                 time.sleep(check_freq)
                 gp_resp = gone_pro.get_tables(job_id=gp_resp["JobId"])
-                if gp_resp["JobStatus"].lower().endswith("succes"):
-                    break
         tables = table_list(gp_resp)
     else:
         from camelot.io import read_pdf

--- a/camelot_pro/__init__.py
+++ b/camelot_pro/__init__.py
@@ -66,7 +66,10 @@ def read_pdf(
         else:
             gp_resp = gone_pro.get_tables(pro_kwargs["job_id"])
 
-        if gp_resp["JobStatus"].lower().startswith("process") and pro_kwargs.get("wait_time", 0):
+        # Added default wait time, because early users are confused of no output
+        pro_kwargs["wait_time"] = pro_kwargs.get("wait_time", 30)
+
+        if gp_resp["JobStatus"].lower().startswith("process") and pro_kwargs["wait_time"]:
             wait_time = min(int(pro_kwargs["wait_time"]), 90)
             check_freq = max(math.ceil(wait_time/4), 10)
             for _ in range(math.ceil(wait_time/check_freq)):

--- a/camelot_pro/__version__.py
+++ b/camelot_pro/__version__.py
@@ -1,6 +1,6 @@
-VERSION = (0, 7, 3)
+VERSION = (0, 7, 4)
 PRERELEASE = None  # "alpha", "beta" or "rc"
-REVISION = 3
+REVISION = None
 
 
 def generate_version(version, prerelease=None, revision=None):

--- a/camelot_pro/__version__.py
+++ b/camelot_pro/__version__.py
@@ -1,6 +1,6 @@
 VERSION = (0, 7, 3)
 PRERELEASE = None  # "alpha", "beta" or "rc"
-REVISION = 2
+REVISION = 3
 
 
 def generate_version(version, prerelease=None, revision=None):

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,6 @@
 | Version 	| Type 	| Description 	| Release Date 	|
 |---------	|-----------------	|---------------------------------------------------	|--------------	|
+| 0.7.4 	| Enhancement 	| Set default `wait_for_output` to `True` in pro_kwargs  | 10/03/2019 	|
 | 0.7.3.2 	| Informative 	| Provide informative message to user based on the respone 	| 09/25/2019 	|
 | 0.7.3.1 	| Bug Fix 	| Inability to handle idempotent request's response 	| 08/28/2019 	|
 | 0.7.3 	| First Release 	| To compact camelot-py's 0.7.3 	| 08/25/2019 	|


### PR DESCRIPTION
Set default `wait_for_output` to `True` in pro_kwargs to make it easier for early adopters

